### PR TITLE
Add Terraform deployment to AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,28 @@ A small Flask service that exposes an endpoint `/data` returning a JSON message 
 
 Another Flask service that queries Consul to discover `service_a`. It then requests data from `service_a` and exposes the result on `/fetch` together with its own status. A `/health` endpoint is also provided.
 
+
+## Deploy on AWS using Terraform
+
+You can run the demo on AWS instead of locally by provisioning an EC2 instance
+that automatically starts the Docker Compose environment.
+
+1. Install [Terraform](https://www.terraform.io/downloads).
+2. Edit the variables in `terraform/variables.tf` if needed. At a minimum set
+   `repo_url` to a repository that contains this project and `key_name` to an
+   existing EC2 key pair. Optionally provide `public_key_path` to create the key
+   pair automatically.
+3. Initialise and apply the Terraform configuration:
+
+   ```bash
+   cd terraform
+   terraform init
+   terraform apply
+   ```
+
+After the apply completes, Terraform outputs the public IP address of the EC2
+instance. The services will be accessible on the following ports:
+
+- Consul UI: `http://<public_ip>:8500`
+- Service A: `http://<public_ip>:5000/data`
+- Service B: `http://<public_ip>:5001/fetch`

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,75 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_security_group" "demo" {
+  name        = "service-mesh-demo-sg"
+  description = "Allow HTTP and Consul"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 5000
+    to_port     = 5001
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 8500
+    to_port     = 8500
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+resource "aws_instance" "demo" {
+  ami                    = data.aws_ami.amazon_linux.id
+  instance_type          = var.instance_type
+  vpc_security_group_ids = [aws_security_group.demo.id]
+  key_name               = var.key_name
+  user_data              = data.template_file.user_data.rendered
+  tags = {
+    Name = "service-mesh-demo"
+  }
+}
+
+resource "aws_key_pair" "default" {
+  count      = var.public_key_path != "" ? 1 : 0
+  key_name   = var.key_name
+  public_key = file(var.public_key_path)
+}
+
+data "template_file" "user_data" {
+  template = file("${path.module}/user_data.sh")
+  vars = {
+    repo_url = var.repo_url
+  }
+}
+

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "instance_public_ip" {
+  description = "Public IP of EC2 instance"
+  value       = aws_instance.demo.public_ip
+}

--- a/terraform/user_data.sh
+++ b/terraform/user_data.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+yum update -y
+amazon-linux-extras install docker -y
+service docker start
+usermod -a -G docker ec2-user
+curl -L "https://github.com/docker/compose/releases/download/v2.20.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+su - ec2-user -c "git clone ${repo_url} app && cd app && docker-compose up -d --build"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,29 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "key_name" {
+  description = "Name of the SSH key pair to use"
+  type        = string
+  default     = "demo-key"
+}
+
+variable "public_key_path" {
+  description = "Path to public key file to create key pair"
+  type        = string
+  default     = ""
+}
+
+variable "repo_url" {
+  description = "Git repository URL containing the demo"
+  type        = string
+  default     = "https://github.com/example/service_mesh_demo.git"
+}


### PR DESCRIPTION
## Summary
- add Terraform code to deploy the Docker Compose demo on AWS EC2
- update README with instructions for running the demo via Terraform

## Testing
- `terraform fmt -recursive`
- `terraform validate` *(fails: provider download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6851362aaa548333be8b1ae07c136b24