### PR TITLE
Add GitHub PAT variable for Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ that automatically starts the Docker Compose environment.
 2. Edit the variables in `terraform/variables.tf` if needed. At a minimum set
    `repo_url` to a repository that contains this project and `key_name` to an
    existing EC2 key pair. Optionally provide `public_key_path` to create the key
-   pair automatically.
-3. Initialise and apply the Terraform configuration:
+   pair automatically. The `github_pat` variable does not have a default and must
+   be supplied at apply time.
+3. Initialise and apply the Terraform configuration, passing your GitHub token:
 
    ```bash
    cd terraform
    terraform init
-   terraform apply
+   terraform apply -var="github_pat=your-github-pat"
    ```
 
 After the apply completes, Terraform outputs the public IP address of the EC2

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -163,9 +163,3 @@ resource "aws_iam_instance_profile" "ec2_profile" {
   name = "ec2_profile"
   role = aws_iam_role.ec2_role.name
 }
-
-variable "github_pat" {
-  description = "GitHub Personal Access Token"
-  type        = string
-  sensitive   = true
-}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -27,3 +27,9 @@ variable "repo_url" {
   type        = string
   default     = "https://github.com/example/service_mesh_demo.git"
 }
+
+variable "github_pat" {
+  description = "GitHub Personal Access Token"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary
- define a `github_pat` variable in `terraform/variables.tf`
- remove inline PAT variable from `terraform/main.tf`
- document passing the PAT when running `terraform apply`

## Testing
- `terraform fmt -check` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685515236ee88333b4a9f5eaad2f1ac7