### PR TITLE
Enable Consul mTLS with sidecar proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Service Mesh Demo
 
-This repository demonstrates a simple service mesh scenario using Consul for service discovery. Two Flask services are provided and orchestrated using Docker Compose.
+This repository demonstrates a simple service mesh scenario using Consul for service discovery. The configuration enables Consul Connect with mutual TLS so service-to-service traffic is encrypted. Two Flask services are provided and orchestrated using Docker Compose.
 
 ## Prerequisites
 
@@ -16,7 +16,7 @@ This repository demonstrates a simple service mesh scenario using Consul for ser
    ```
 3. Access the Consul UI at [http://localhost:8500](http://localhost:8500).
 4. Test Service A by visiting [http://localhost:5000/data](http://localhost:5000/data).
-5. Test Service B which fetches data from Service A via Consul by visiting [http://localhost:5001/fetch](http://localhost:5001/fetch).
+5. Test Service B which now reaches Service A through the Consul Connect service mesh by visiting [http://localhost:5001/fetch](http://localhost:5001/fetch).
 
 ## Services
 
@@ -26,7 +26,7 @@ A small Flask service that exposes an endpoint `/data` returning a JSON message 
 
 ### service_b
 
-Another Flask service that queries Consul to discover `service_a`. It then requests data from `service_a` and exposes the result on `/fetch` together with its own status. A `/health` endpoint is also provided.
+Another Flask service that communicates with `service_a` through the Consul Connect service mesh. It requests data via its local sidecar proxy and exposes the result on `/fetch` together with its own status. A `/health` endpoint is also provided.
 
 
 ## Deploy on AWS using Terraform

--- a/consul.hcl
+++ b/consul.hcl
@@ -1,0 +1,3 @@
+connect {
+  enabled = true
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     restart: always
     volumes:
      - ./service_a.hcl:/etc/consul.d/service_a.hcl
+     - ./service_b.hcl:/etc/consul.d/service_b.hcl
+     - ./consul.hcl:/etc/consul.d/consul.hcl
     ports:
       - "8500:8500"
       - "8600:8600/tcp"
@@ -22,12 +24,18 @@ services:
     container_name: service_a
     ports:
       - "5000:5000"
-    environment:
-      - CONSUL_HTTP_ADDR=http://consul:8500
     networks:
       - app-network
     depends_on:
       - consul
+
+  service_a_proxy:
+    image: hashicorp/consul:1.15
+    command: "connect proxy -sidecar-for service_a"
+    network_mode: "service:service_a"
+    depends_on:
+      - consul
+      - service_a
     
 
   service_b:
@@ -39,12 +47,20 @@ services:
     ports:
       - "5001:5001"
     environment:
-      - CONSUL_HTTP_ADDR=http://consul:8500
+      - SERVICE_A_URL=http://localhost:8080/data
     networks:
       - app-network
     depends_on:
       - consul
       - service_a
+
+  service_b_proxy:
+    image: hashicorp/consul:1.15
+    command: "connect proxy -sidecar-for service_b -upstream service_a:8080"
+    network_mode: "service:service_b"
+    depends_on:
+      - consul
+      - service_b
    
 networks:
   app-network:

--- a/service_a.hcl
+++ b/service_a.hcl
@@ -3,6 +3,10 @@ service {
   address = "service_a"
   port    = 5000
 
+  connect {
+    sidecar_service {}
+  }
+
   check {
     http     = "http://service_a:5000/health"
     interval = "10s"

--- a/service_b.hcl
+++ b/service_b.hcl
@@ -1,0 +1,24 @@
+service {
+  name    = "service_b"
+  address = "service_b"
+  port    = 5001
+
+  connect {
+    sidecar_service {
+      proxy {
+        upstreams = [
+          {
+            destination_name = "service_a"
+            local_bind_port  = 8080
+          }
+        ]
+      }
+    }
+  }
+
+  check {
+    http     = "http://service_b:5001/health"
+    interval = "10s"
+    timeout  = "5s"
+  }
+}

--- a/service_b.py
+++ b/service_b.py
@@ -1,34 +1,21 @@
 from flask import Flask, jsonify
 import requests
+import os
 
 app = Flask(__name__)
 
-CONSUL_URL = "http://consul:8500/v1/catalog/service/service_a"
+SERVICE_A_URL = os.environ.get("SERVICE_A_URL", "http://localhost:8080/data")
 
 @app.route('/fetch', methods=['GET'])
 def fetch_from_service_a():
     try:
-        # Query Consul for Service A's address
-        response = requests.get(CONSUL_URL)
+        response = requests.get(SERVICE_A_URL)
         if response.status_code == 200:
-            service_instances = response.json()
-            if not service_instances:
-                return jsonify({"error": "No instances of service_a found in Consul"}), 404
-            service_info = service_instances[0]  # Get the first instance
-            service_a_address = service_info['ServiceAddress']
-            service_a_port = service_info['ServicePort']
-
-            # Call Service A
-            service_a_url = f"http://{service_a_address}:{service_a_port}/data"
-            service_a_response = requests.get(service_a_url)
-            if service_a_response.status_code == 200:
-                return jsonify({"service_b_message": "Data received", "service_a_data": service_a_response.json()}), 200
-            else:
-                return jsonify({"error": "Failed to fetch data from Service A"}), service_a_response.status_code
+            return jsonify({"service_b_message": "Data received", "service_a_data": response.json()}), 200
         else:
-            return jsonify({"error": "Failed to query Consul"}), response.status_code
+            return jsonify({"error": "Failed to fetch data from Service A"}), response.status_code
     except requests.exceptions.RequestException as e:
-        return jsonify({"error": f"Connection to Consul failed: {str(e)}"}), 500
+        return jsonify({"error": f"Request to Service A failed: {str(e)}"}), 500
 
 @app.route('/health', methods=['GET'])
 def health_check():


### PR DESCRIPTION
## Summary
- enable Consul Connect with TLS via new `consul.hcl`
- register Service B with upstream for Service A
- add Consul sidecar proxy containers for each service
- update Service B to call Service A through the mesh
- document the mTLS setup in README

## Testing
- `python3 -m py_compile service_a.py service_b.py`
- `terraform fmt -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68578893f3c883339840986a099674a2