### PR TITLE
Add SAN docs and cert generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ This repository demonstrates a simple service mesh scenario using Consul for ser
 
 Self-signed certificates used by the demo are stored in the `certs/` directory. The root CA is `ca.pem`. Import this certificate into your browser or use the `--cacert` option with curl when accessing the HTTPS endpoints locally.
 
+The included server certificates contain only a Common Name and lack Subject
+Alternative Name (SAN) fields. Modern browsers require a SAN matching the host
+name, so you may see an error like *"This server couldn't prove that it's
+localhost"*. Run `scripts/generate_certs.sh` to regenerate the certificates with
+SAN entries for `localhost`, then re-import `certs/ca.pem` if needed.
+
 ## Services
 
 ### service_a

--- a/scripts/generate_certs.sh
+++ b/scripts/generate_certs.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CERT_DIR="$(dirname "$0")/../certs"
+mkdir -p "$CERT_DIR"
+cd "$CERT_DIR"
+
+# Generate CA
+openssl genrsa -out ca-key.pem 4096
+openssl req -new -x509 -days 3650 -key ca-key.pem -subj "/CN=Demo CA" -out ca.pem
+
+create_cert() {
+  local name=$1
+  cat > openssl.cnf <<CONFIG
+[ req ]
+default_bits       = 2048
+prompt             = no
+default_md         = sha256
+distinguished_name = dn
+req_extensions     = req_ext
+
+[ dn ]
+CN = $name
+
+[ req_ext ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = $name
+DNS.2 = localhost
+CONFIG
+
+  openssl genrsa -out ${name}-key.pem 4096
+  openssl req -new -key ${name}-key.pem -out ${name}.csr -config openssl.cnf
+  openssl x509 -req -days 365 -in ${name}.csr -CA ca.pem -CAkey ca-key.pem \
+    -CAcreateserial -out ${name}.pem -extensions req_ext -extfile openssl.cnf
+  rm -f ${name}.csr openssl.cnf
+}
+
+create_cert consul-server
+create_cert service_a
+create_cert service_b
+
+echo "Certificates generated in $CERT_DIR"


### PR DESCRIPTION
## Summary
- document SAN issue with existing certs in README
- add script to regenerate demo certs with SAN entries

## Testing
- `python -m py_compile service_a.py service_b.py`

------
https://chatgpt.com/codex/tasks/task_e_685a5aa0e9ec8333bc52479e5992d34e