### PR TITLE
Fix mTLS service_a health check

### DIFF
--- a/service_a.hcl
+++ b/service_a.hcl
@@ -4,9 +4,15 @@ service {
   port    = 5000
 
   check {
-    http            = "https://service_a:5000/health"
-    interval        = "10s"
-    timeout         = "5s"
-    tls_skip_verify = true
+    args = [
+      "curl",
+      "-fsS",
+      "--cert", "/consul/certs/service_b.pem",
+      "--key", "/consul/certs/service_b-key.pem",
+      "--cacert", "/consul/certs/ca.pem",
+      "https://service_a:5000/health"
+    ]
+    interval = "10s"
+    timeout  = "5s"
   }
 }


### PR DESCRIPTION
## Summary
- update `service_a.hcl` health check to use curl with a client certificate

## Testing
- `python -m py_compile service_a.py service_b.py`

------
https://chatgpt.com/codex/tasks/task_e_685e33db6a7883339630e9875db1c107